### PR TITLE
Allow charmcraft upload to be retried

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ extend-exclude = ["__pycache__", "*.egg_info"]
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # ignore = ["E501", "D107", "RET504", "C901"]
+ignore = ["C901"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"], "tests/constants.py" = ["E501"]}
 extend-select = ["I"]

--- a/tests/test_charmcraft.py
+++ b/tests/test_charmcraft.py
@@ -12,7 +12,7 @@ import tests.constants as constants
 @pytest.mark.parametrize("metadata_file", ["metadata.yaml", "charmcraft.yaml", None])
 def test_metadata(metadata_file):
     if metadata_file:
-        # Patch os.path.exists to retun True only for metadata_file
+        # Patch os.path.exists to return True only for metadata_file
         with patch(
             "os.path.exists",
             MagicMock(side_effect=lambda x: True if x == metadata_file else False),

--- a/tests/test_charmcraft.py
+++ b/tests/test_charmcraft.py
@@ -78,8 +78,9 @@ def test_upload(charm_name, path):
                     "blackbox-exporter-image",
                     image="docker://quay.io/prometheus/blackbox-exporter:v0.24.0",
                     format="json",
+                    _tty_out=False,
                 )
-                charmcraft_mock.upload.assert_called_once_with(path, format="json")
+                charmcraft_mock.upload.assert_called_once_with(path, format="json", _tty_out=False)
 
 
 @pytest.mark.parametrize("resources", [(["resA:1", "resB:2"]), (["resA:1", "resB:2"])])
@@ -95,7 +96,11 @@ def test_release(resources: List[str]):
         )
         resources_args = [f"--resource={r}" for r in resources]
         charmcraft_mock.release.assert_called_once_with(
-            charm, *resources_args, channel=channel, revision=revision
+            charm,
+            *resources_args,
+            channel=channel,
+            revision=revision,
+            _tty_out=False,
         )
 
 
@@ -256,6 +261,7 @@ def test_publish_charm_libraries():
                         "publish-lib",
                         "charms.blackbox_exporter_k8s.v0.blackbox_probes",
                         format="json",
+                        _tty_out=False,
                     )
                 ]
             )

--- a/tests/test_rockcraft.py
+++ b/tests/test_rockcraft.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 import services.rockcraft as rockcraft
 import tests.constants as constants
@@ -53,7 +54,7 @@ def test_oci_factory_manifest():
     commit = "abcdef123"
     versions_with_tags = {"1.0.0": ["1.0.0"], "1.0.1": ["1", "1.0", "1.0.1"]}
     end_of_life_date = datetime.now() + timedelta(days=365 / 4)
-    end_of_life = f"{end_of_life_date.strftime("%Y-%m-%d")}T00:00:00Z"
+    end_of_life = f"{end_of_life_date.strftime('%Y-%m-%d')}T00:00:00Z"
 
     expected_manifest = {
         "version": 1,
@@ -76,7 +77,9 @@ def test_oci_factory_manifest():
             },
         ],
     }
-    manifest = rockcraft.oci_factory_manifest(repository, commit, versions_with_tags)
+    manifest: Dict = yaml.safe_load(
+        rockcraft.oci_factory_manifest(repository, commit, versions_with_tags)
+    )
     # Make sure all the uploads point to the same repo and commit
     assert len({x["source"] for x in manifest["upload"]}) == 1  # pyright: ignore
     assert len({x["commit"] for x in manifest["upload"]}) == 1  # pyright: ignore

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ commands =
 deps =
   pyright
   pytest
-  .
 commands =
   pyright {[vars]all_path} {posargs}
 
@@ -50,7 +49,6 @@ passenv =
 deps = 
   pytest
   pytest-cov
-  .
 commands =
   coverage run \
     --source={[vars]src_path} \

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 skipdist = True
 skip_missing_interpreters = True
+isolated_build = True
 envlist = lint, static, unit
 
 [vars]
@@ -49,6 +50,11 @@ passenv =
 deps = 
   pytest
   pytest-cov
+  sh
+  typer
+  tenacity
+  requests
+  rich
 commands =
   coverage run \
     --source={[vars]src_path} \


### PR DESCRIPTION
Ported from https://github.com/canonical/data-platform-workflows/pull/285

Solves issue where upload-resource fails and re-triggering calling workflow is not possible since upload-charm fails on subsequent retries. The AI team is especially affected by this, since they have many charms in a single repository. Details: https://github.com/canonical/data-platform-workflows/issues/22