### PR TITLE
fix: set support for patch releases to yesterday

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
-          sudo snap install charmcraft --channel=3.x/candidate
+          sudo snap install charmcraft --channel=3.x/candidate --classic
           python -m pip install tox
       - name: Run Linter
         run: tox -e lint

--- a/src/services/rockcraft.py
+++ b/src/services/rockcraft.py
@@ -135,7 +135,7 @@ def oci_factory_manifest(
             return super().increase_indent(flow, False)
 
     end_of_life_date = datetime.now() + timedelta(days=365 / 4)  # EOL is 3 months by default
-    end_of_life_patch_date = datetime.now() - timedelta(days=1)  # for patch releases, we set EOL to be yesterday
+    end_of_life_patch_date = datetime.now() - timedelta(days=1)  # for patch releases
     end_of_life = f"{end_of_life_date.strftime('%Y-%m-%d')}T00:00:00Z"
     end_of_life_patch = f"{end_of_life_patch_date.strftime('%Y-%m-%d')}T00:00:00Z"
 
@@ -149,7 +149,7 @@ def oci_factory_manifest(
         upload_item["directory"] = version
         upload_item["release"] = {}
         for tag in tags:
-            # for patch tags, we set end-of-life to be "yesterday" so that we don't need to support every version bump
+            # for patch tags, we set end-of-life to be "yesterday"
             is_tag_with_patch = len(tag.split("-")[0].split(".")) == 3
             upload_item["release"][tag] = {
                 "end-of-life": end_of_life_patch if is_tag_with_patch else end_of_life,

--- a/src/services/rockcraft.py
+++ b/src/services/rockcraft.py
@@ -135,7 +135,9 @@ def oci_factory_manifest(
             return super().increase_indent(flow, False)
 
     end_of_life_date = datetime.now() + timedelta(days=365 / 4)  # EOL is 3 months by default
+    end_of_life_patch_date = datetime.now() - timedelta(days=1)  # for patch releases, we set EOL to be yesterday
     end_of_life = f"{end_of_life_date.strftime('%Y-%m-%d')}T00:00:00Z"
+    end_of_life_patch = f"{end_of_life_patch_date.strftime('%Y-%m-%d')}T00:00:00Z"
 
     manifest = {}
     manifest["version"] = 1
@@ -147,8 +149,10 @@ def oci_factory_manifest(
         upload_item["directory"] = version
         upload_item["release"] = {}
         for tag in tags:
+            # for patch tags, we set end-of-life to be "yesterday" so that we don't need to support every version bump
+            is_tag_with_patch = len(tag.split("-")[0].split(".")) == 3
             upload_item["release"][tag] = {
-                "end-of-life": end_of_life,
+                "end-of-life": end_of_life_patch if is_tag_with_patch else end_of_life,
                 "risks": ["stable"],
             }
         manifest["upload"].append(upload_item)

--- a/tests/test_rockcraft.py
+++ b/tests/test_rockcraft.py
@@ -55,6 +55,8 @@ def test_oci_factory_manifest():
     versions_with_tags = {"1.0.0": ["1.0.0"], "1.0.1": ["1", "1.0", "1.0.1"]}
     end_of_life_date = datetime.now() + timedelta(days=365 / 4)
     end_of_life = f"{end_of_life_date.strftime('%Y-%m-%d')}T00:00:00Z"
+    end_of_life_patch_date = datetime.now() - timedelta(days=1)
+    end_of_life_patch = f"{end_of_life_patch_date.strftime('%Y-%m-%d')}T00:00:00Z"
 
     expected_manifest = {
         "version": 1,
@@ -63,7 +65,7 @@ def test_oci_factory_manifest():
                 "source": "canonical/prometheus-rock",
                 "commit": "abcdef123",
                 "directory": "1.0.0",
-                "release": {"1.0.0": {"end-of-life": end_of_life, "risks": ["stable"]}},
+                "release": {"1.0.0": {"end-of-life": end_of_life_patch, "risks": ["stable"]}},
             },
             {
                 "source": "canonical/prometheus-rock",
@@ -72,7 +74,7 @@ def test_oci_factory_manifest():
                 "release": {
                     "1": {"end-of-life": end_of_life, "risks": ["stable"]},
                     "1.0": {"end-of-life": end_of_life, "risks": ["stable"]},
-                    "1.0.1": {"end-of-life": end_of_life, "risks": ["stable"]},
+                    "1.0.1": {"end-of-life": end_of_life_patch, "risks": ["stable"]},
                 },
             },
         ],


### PR DESCRIPTION
For patch releases, we don't want to support them for 3 months as a new patch on the same branch might already fix the issue we're experiencing. Noctua still creates OCI-factory manifests with a 3-month support window for every tag: see https://github.com/canonical/oci-factory/pull/368 . 

This PR sets the support window for patch releases to be "yesterday".