### PR TITLE
fix: use image.yaml v2

### DIFF
--- a/src/services/rockcraft.py
+++ b/src/services/rockcraft.py
@@ -147,7 +147,7 @@ def oci_factory_manifest(
     max_supported_tag_level = {"major": 1, "minor": 2, "patch": 3}[support]
 
     manifest = {}
-    manifest["version"] = 1
+    manifest["version"] = 2
     manifest["upload"] = []
     for version, tags in versions_with_tags.items():
         upload_item = {}

--- a/tests/test_rockcraft.py
+++ b/tests/test_rockcraft.py
@@ -59,7 +59,7 @@ def test_oci_factory_manifest():
     end_of_life_patch = f"{end_of_life_patch_date.strftime('%Y-%m-%d')}T00:00:00Z"
 
     expected_manifest = {
-        "version": 1,
+        "version": 2,
         "upload": [
             {
                 "source": "canonical/prometheus-rock",
@@ -100,7 +100,7 @@ def test_oci_factory_manifest_with_risk_track(risk_track):
     end_of_life_patch = f"{end_of_life_patch_date.strftime('%Y-%m-%d')}T00:00:00Z"
 
     expected_manifest = {
-        "version": 1,
+        "version": 2,
         "upload": [
             {
                 "source": "canonical/prometheus-rock",


### PR DESCRIPTION
Using image trigger v2 since rocks need to start using that in OCI Factory.